### PR TITLE
Pinning poetry version to avoid unexpected changes in the tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.8
 
-RUN pip install poetry
+ARG POETRY_VERSION=1.0.5
+
+RUN pip install poetry=="$POETRY_VERSION"
 
 COPY service /service
 
@@ -8,4 +10,4 @@ WORKDIR /service
 
 RUN poetry install
 
-CMD poetry run fexservice
+CMD ["poetry", "run", "fexservice"]


### PR DESCRIPTION
Essa alteração apenas pina a versão do poetry na imagem, isso vai evitar que o `pip` baixe sempre a última versão do `poetry` e talvez introduza problemas que não consigamos reproduzir.

A mudança no `CMD` tentar seguir as [best practices when writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#cmd)